### PR TITLE
Add FIXED_POINTS_NO_RANDOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This means:
 These are symbols you can define prior to library inclusion to alter the behaviour of the library.
 
 - `FIXED_POINTS_USE_NAMESPACE`: Define this to wrap all classes and functions in the namespace `FixedPoints`. Useful for preventing naming conflicts.
+- `FIXED_POINTS_NO_RANDOM`: Define this to disable the random utility functions. Useful for systems that don't have access to `long random(void)` from avr-libc.
 
 ## Contents
 This library supplies two core types and sixteen type aliases.

--- a/src/FixedPoints/Details.h
+++ b/src/FixedPoints/Details.h
@@ -167,6 +167,7 @@ namespace FIXED_POINTS_DETAILS
 	using DecimalLiteralF = decltype(0.0F);
 	using DecimalLiteralL = decltype(0.0L);
 	
+#if !defined(FIXED_POINTS_NO_RANDOM)
 	template< typename T >
 	struct RandomHelper;
 	
@@ -217,6 +218,7 @@ namespace FIXED_POINTS_DETAILS
 	{
 		static inline int64_t Random() { return (static_cast<int64_t>(random()) << 32) | static_cast<int64_t>(random()); }
 	};
+#endif
 
 	///////////////////////
 	// Here be dragons!! //

--- a/src/FixedPoints/Utils.h
+++ b/src/FixedPoints/Utils.h
@@ -23,6 +23,7 @@
 //
 
 FIXED_POINTS_BEGIN_NAMESPACE
+
 template< unsigned Integer, unsigned Fraction >
 constexpr UFixed<Integer, Fraction> floorFixed(const UFixed<Integer, Fraction> & value);
 
@@ -60,6 +61,7 @@ constexpr UFixed<Integer, Fraction> nextafterFixed(const UFixed<Integer, Fractio
 // Unsigned Random
 //
 
+#if !defined(FIXED_POINTS_NO_RANDOM)
 template< unsigned Integer, unsigned Fraction >
 UFixed<Integer, Fraction> randomUFixed(void);
 
@@ -68,11 +70,13 @@ UFixed<Integer, Fraction> randomUFixed(const UFixed<Integer, Fraction> & exclusi
 
 template< unsigned Integer, unsigned Fraction >
 UFixed<Integer, Fraction> randomUFixed(const UFixed<Integer, Fraction> & inclusiveLowerBound, const UFixed<Integer, Fraction> & exclusiveUpperBound);
+#endif
 
 //
 // Signed Random
 //
 
+#if !defined(FIXED_POINTS_NO_RANDOM)
 template< unsigned Integer, unsigned Fraction >
 SFixed<Integer, Fraction> randomSFixed(void);
 
@@ -81,6 +85,8 @@ SFixed<Integer, Fraction> randomSFixed(const SFixed<Integer, Fraction> & exclusi
 
 template< unsigned Integer, unsigned Fraction >
 SFixed<Integer, Fraction> randomSFixed(const SFixed<Integer, Fraction> & inclusiveLowerBound, const SFixed<Integer, Fraction> & exclusiveUpperBound);
+#endif
+
 FIXED_POINTS_END_NAMESPACE
 
 //
@@ -88,6 +94,7 @@ FIXED_POINTS_END_NAMESPACE
 //
 
 FIXED_POINTS_BEGIN_NAMESPACE
+
 template< unsigned Integer, unsigned Fraction >
 constexpr UFixed<Integer, Fraction> floorFixed(const UFixed<Integer, Fraction> & value)
 {
@@ -199,6 +206,7 @@ constexpr UFixed<Integer, Fraction> nextafterFixed(const UFixed<Integer, Fractio
 // Unsigned Random
 //
 
+#if !defined(FIXED_POINTS_NO_RANDOM)
 template< unsigned Integer, unsigned Fraction >
 UFixed<Integer, Fraction> randomUFixed(void)
 {
@@ -219,11 +227,13 @@ UFixed<Integer, Fraction> randomUFixed(const UFixed<Integer, Fraction> & inclusi
 	using InternalType = typename UFixed<Integer, Fraction>::InternalType;
 	return UFixed<Integer, Fraction>::fromInternal(inclusiveLowerBound.getInternal() + (FIXED_POINTS_DETAILS::RandomHelper<InternalType>::Random() % (exclusiveUpperBound.getInternal() - inclusiveLowerBound.getInternal())));
 }
+#endif
 
 //
 // Signed Random
 //
 
+#if !defined(FIXED_POINTS_NO_RANDOM)
 template< unsigned Integer, unsigned Fraction >
 SFixed<Integer, Fraction> randomSFixed(void)
 {
@@ -245,4 +255,6 @@ SFixed<Integer, Fraction> randomSFixed(const SFixed<Integer, Fraction> & inclusi
 	auto value = FIXED_POINTS_DETAILS::RandomHelper<InternalType>::Random();
 	return SFixed<Integer, Fraction>::fromInternal(inclusiveLowerBound.getInternal() + (abs(value) % (exclusiveUpperBound.getInternal() - inclusiveLowerBound.getInternal())));
 }
+#endif
+
 FIXED_POINTS_END_NAMESPACE


### PR DESCRIPTION
This is a feature that will disable the random utility functions if they are causing issues due to the lack of avr-libc on non-Arduino boards that try to adhere to the Arduino functions.