### PR TITLE
Add workaround for gcc bug 58541

### DIFF
--- a/src/FixedPoints/SFixed.h
+++ b/src/FixedPoints/SFixed.h
@@ -89,41 +89,16 @@ public:
 	SFixed & operator /=(const SFixed & other);
 	
 public:
-	const static SFixed Epsilon;
-	const static SFixed MinValue;
-	const static SFixed MaxValue;
+	constexpr const static SFixed Epsilon = SFixed::fromInternal(1);
+	constexpr const static SFixed MinValue = SFixed::fromInternal(FIXED_POINTS_DETAILS::MsbMask<InternalSize>::Value);
+	constexpr const static SFixed MaxValue = SFixed::fromInternal(~FIXED_POINTS_DETAILS::MsbMask<InternalSize>::Value);
 	
-	const static SFixed Pi;
-	const static SFixed E;
-	const static SFixed Phi;
-	const static SFixed Tau;
+	// 40 digits is probably enough for these
+	constexpr const static SFixed Pi = 3.1415926535897932384626433832795028841971;
+	constexpr const static SFixed E = 2.718281828459045235360287471352662497757;
+	constexpr const static SFixed Phi = 1.6180339887498948482045868343656381177203;
+	constexpr const static SFixed Tau = 6.2831853071795864769252867665590057683943;
 };
-
-//
-// Variables
-//
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const SFixed<Integer, Fraction> SFixed<Integer, Fraction>::Epsilon = SFixed<Integer, Fraction>::fromInternal(1);
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const SFixed<Integer, Fraction> SFixed<Integer, Fraction>::MinValue = SFixed::fromInternal(FIXED_POINTS_DETAILS::MsbMask<InternalSize>::Value);
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const SFixed<Integer, Fraction> SFixed<Integer, Fraction>::MaxValue = SFixed::fromInternal(~FIXED_POINTS_DETAILS::MsbMask<InternalSize>::Value);
-
-// 40 digits is probably enough for these
-template< unsigned Integer, unsigned Fraction >
-constexpr const SFixed<Integer, Fraction> SFixed<Integer, Fraction>::Pi = 3.1415926535897932384626433832795028841971;
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const SFixed<Integer, Fraction> SFixed<Integer, Fraction>::E = 2.718281828459045235360287471352662497757;
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const SFixed<Integer, Fraction> SFixed<Integer, Fraction>::Phi = 1.6180339887498948482045868343656381177203;
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const SFixed<Integer, Fraction> SFixed<Integer, Fraction>::Tau = 6.2831853071795864769252867665590057683943;
 
 
 //

--- a/src/FixedPoints/UFixed.h
+++ b/src/FixedPoints/UFixed.h
@@ -88,41 +88,16 @@ public:
 	UFixed & operator /=(const UFixed & other);
 	
 public:
-	const static UFixed Epsilon;
-	const static UFixed MinValue;
-	const static UFixed MaxValue;
+	constexpr const static UFixed Epsilon = UFixed::fromInternal(1);
+	constexpr const static UFixed MinValue = UFixed::fromInternal(0);
+	constexpr const static UFixed MaxValue = UFixed::fromInternal(~0);
 	
-	const static UFixed Pi;
-	const static UFixed E;
-	const static UFixed Phi;
-	const static UFixed Tau;
+	// 40 digits is probably enough for these
+	constexpr const static UFixed Pi = 3.1415926535897932384626433832795028841971;
+	constexpr const static UFixed E = 2.718281828459045235360287471352662497757;
+	constexpr const static UFixed Phi = 1.6180339887498948482045868343656381177203;
+	constexpr const static UFixed Tau = 6.2831853071795864769252867665590057683943;
 };
-
-//
-// Variables
-//
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const UFixed<Integer, Fraction> UFixed<Integer, Fraction>::Epsilon = UFixed<Integer, Fraction>::fromInternal(1);
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const UFixed<Integer, Fraction> UFixed<Integer, Fraction>::MinValue = UFixed::fromInternal(0);
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const UFixed<Integer, Fraction> UFixed<Integer, Fraction>::MaxValue = UFixed::fromInternal(~0);
-
-// 40 digits is probably enough for these
-template< unsigned Integer, unsigned Fraction >
-constexpr const UFixed<Integer, Fraction> UFixed<Integer, Fraction>::Pi = 3.1415926535897932384626433832795028841971;
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const UFixed<Integer, Fraction> UFixed<Integer, Fraction>::E = 2.718281828459045235360287471352662497757;
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const UFixed<Integer, Fraction> UFixed<Integer, Fraction>::Phi = 1.6180339887498948482045868343656381177203;
-
-template< unsigned Integer, unsigned Fraction >
-constexpr const UFixed<Integer, Fraction> UFixed<Integer, Fraction>::Tau = 6.2831853071795864769252867665590057683943;
 
 
 //


### PR DESCRIPTION
The bug in question causes a "redeclaration differs in constexpr" error, despite the standard not requiring this.
This bug is fixed in newer versions of gcc.
More information can be found [here](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58541).