### PR TITLE
Add Serial.begin for boards that need it

### DIFF
--- a/examples/FixedPointCalculations/FixedPointCalculations.ino
+++ b/examples/FixedPointCalculations/FixedPointCalculations.ino
@@ -159,6 +159,7 @@ void TestSQ7x8(void)
 
 void setup()
 {
+	Serial.begin(9600);
 	while(!Serial);
 
 	TestUQ8x8();


### PR DESCRIPTION
Some Arduino boards require `Serial.begin` (e.g. the Uno and the Due) whilst others appear to not need it (e.g. the Arduboy).