### PR TITLE
Add Arduino Due support

### DIFF
--- a/src/FixedPoints/Details.h
+++ b/src/FixedPoints/Details.h
@@ -31,7 +31,7 @@
 #define FIXED_POINTS_DETAILS FixedPointsDetails
 #endif
 
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(ARDUINO_SAM_DUE)
 #define FIXED_POINTS_NO_RANDOM
 #endif
 


### PR DESCRIPTION
Automatically disables random number functionality for Arduino Due.