### PR TITLE
Replace inferred literal types

### DIFF
--- a/src/FixedPoints/Details.h
+++ b/src/FixedPoints/Details.h
@@ -135,17 +135,6 @@ namespace FIXED_POINTS_DETAILS
 		IdentityMask(void) = delete;
 		constexpr const static LeastUInt<0> Value = 0;
 	};
-
-	using IntegerLiteral = decltype(0);
-	using IntegerLiteralU = decltype(0U);
-	using IntegerLiteralL = decltype(0L);
-	using IntegerLiteralUL = decltype(0UL);
-	using IntegerLiteralLL = decltype(0LL);
-	using IntegerLiteralULL = decltype(0ULL);
-
-	using DecimalLiteral = decltype(0.0);
-	using DecimalLiteralF = decltype(0.0F);
-	using DecimalLiteralL = decltype(0.0L);
 	
 #if !defined(FIXED_POINTS_NO_RANDOM)
 	template< typename T >

--- a/src/FixedPoints/SFixedBase.h
+++ b/src/FixedPoints/SFixedBase.h
@@ -47,32 +47,47 @@ namespace FIXED_POINTS_DETAILS
 		constexpr SFixedBase(const RawType & value) : value(static_cast<InternalType>(value)) {}
 		
 	public:
-		constexpr SFixedBase(const IntegerLiteral & value)
-			: value(static_cast<InternalType>(static_cast<LargerType<IntegerLiteral, InternalType> >(value) <<  Fraction)) {}
-			
-		constexpr SFixedBase(const IntegerLiteralU & value)
-			: value(static_cast<InternalType>(static_cast<LargerType<IntegerLiteralU, InternalType> >(value) <<  Fraction)) {}
-			
-		constexpr SFixedBase(const IntegerLiteralL & value)
-			: value(static_cast<InternalType>(static_cast<LargerType<IntegerLiteralL, InternalType> >(value) <<  Fraction)) {}
-			
-		constexpr SFixedBase(const IntegerLiteralUL & value)
-			: value(static_cast<InternalType>(static_cast<LargerType<IntegerLiteralUL, InternalType>>(value) <<  Fraction)) {}
-			
-		constexpr SFixedBase(const IntegerLiteralLL & value)
-			: value(static_cast<InternalType>(static_cast<LargerType<IntegerLiteralLL, InternalType>>(value) <<  Fraction)) {}
-			
-		constexpr SFixedBase(const IntegerLiteralULL & value)
-			: value(static_cast<InternalType>(static_cast<LargerType<IntegerLiteralULL, InternalType> >(value) <<  Fraction)) {}
-			
-		constexpr SFixedBase(const DecimalLiteral & value)
-			: value(static_cast<InternalType>(value * Scale)) {}
-			
-		constexpr SFixedBase(const DecimalLiteralF & value)
-			: value(static_cast<InternalType>(value * Scale)) {}
-			
-		constexpr SFixedBase(const DecimalLiteralL & value)
-			: value(static_cast<InternalType>(value * Scale)) {}
+		constexpr SFixedBase(const char & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<char, InternalType> >(value) << Fraction)) {}
+
+		constexpr SFixedBase(const unsigned char & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<unsigned char, InternalType> >(value) << Fraction)) {}
+
+		constexpr SFixedBase(const signed char & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<signed char, InternalType> >(value) << Fraction)) {}
+
+		constexpr SFixedBase(const unsigned short int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<unsigned short int, InternalType> >(value) << Fraction)) {}
+
+		constexpr SFixedBase(const signed short int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<signed short int, InternalType> >(value) << Fraction)) {}
+
+		constexpr SFixedBase(const unsigned int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<unsigned int, InternalType> >(value) << Fraction)) {}
+
+		constexpr SFixedBase(const signed int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<signed int, InternalType> >(value) << Fraction)) {}
+
+		constexpr SFixedBase(const unsigned long int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<unsigned long int, InternalType> >(value) << Fraction)) {}
+
+		constexpr SFixedBase(const signed long int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<signed long int, InternalType> >(value) << Fraction)) {}
+
+		constexpr SFixedBase(const unsigned long long int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<unsigned long long int, InternalType> >(value) << Fraction)) {}
+
+		constexpr SFixedBase(const signed long long int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<signed long long int, InternalType> >(value) << Fraction)) {}
+
+		constexpr SFixedBase(const double & value)
+			: value(static_cast<InternalType>(value * static_cast<double>(Scale))) {}
+
+		constexpr SFixedBase(const float & value)
+			: value(static_cast<InternalType>(value * static_cast<float>(Scale))) {}
+
+		constexpr SFixedBase(const long double & value)
+			: value(static_cast<InternalType>(value * static_cast<long double>(Scale))) {}
 	};
 }
 FIXED_POINTS_END_NAMESPACE

--- a/src/FixedPoints/SFixedFreeFunctions.h
+++ b/src/FixedPoints/SFixedFreeFunctions.h
@@ -275,15 +275,20 @@ constexpr auto operator /(const SFixed<IntegerLeft, FractionLeft> & left, const 
 	}
 	
 #define OPERATORS( opType, op ) \
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteral, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteralU, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteralL, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteralUL, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteralLL, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteralULL, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::DecimalLiteral, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::DecimalLiteralF, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::DecimalLiteralL, op )
+	opType##_OPERATOR( char, op )\
+	opType##_OPERATOR( unsigned char, op )\
+	opType##_OPERATOR( signed char, op )\
+	opType##_OPERATOR( unsigned short int, op )\
+	opType##_OPERATOR( signed short int, op )\
+	opType##_OPERATOR( unsigned int, op )\
+	opType##_OPERATOR( signed int, op )\
+	opType##_OPERATOR( unsigned long int, op )\
+	opType##_OPERATOR( signed long int, op )\
+	opType##_OPERATOR( unsigned long long int, op )\
+	opType##_OPERATOR( signed long long int, op )\
+	opType##_OPERATOR( float, op )\
+	opType##_OPERATOR( double, op )\
+	opType##_OPERATOR( long double, op )
 	
 #define LOGIC_OPERATORS( op ) OPERATORS( LOGIC, op )
 #define ARITHMETIC_OPERATORS( op ) OPERATORS( ARITHMETIC, op )

--- a/src/FixedPoints/UFixedBase.h
+++ b/src/FixedPoints/UFixedBase.h
@@ -47,32 +47,47 @@ namespace FIXED_POINTS_DETAILS
 		constexpr UFixedBase(const RawType & value) : value(static_cast<InternalType>(value)) {}
 
 	public:
-		constexpr UFixedBase(const IntegerLiteral & value)
-			: value(static_cast<InternalType>(static_cast< LargerType<IntegerLiteral, InternalType> >(value) << Fraction)) {}
-			
-		constexpr UFixedBase(const IntegerLiteralU & value)
-			: value(static_cast<InternalType>(static_cast< LargerType<IntegerLiteralU, InternalType> >(value) << Fraction)) {}
-			
-		constexpr UFixedBase(const IntegerLiteralL & value)
-			: value(static_cast<InternalType>(static_cast< LargerType<IntegerLiteralL, InternalType> >(value) << Fraction)) {}
-			
-		constexpr UFixedBase(const IntegerLiteralUL & value)
-			: value(static_cast<InternalType>(static_cast< LargerType<IntegerLiteralUL, InternalType>>(value) << Fraction)) {}
-			
-		constexpr UFixedBase(const IntegerLiteralLL & value)
-			: value(static_cast<InternalType>(static_cast< LargerType<IntegerLiteralLL, InternalType>>(value) << Fraction)) {}
-			
-		constexpr UFixedBase(const IntegerLiteralULL & value)
-			: value(static_cast<InternalType>(static_cast< LargerType<IntegerLiteralULL, InternalType> >(value) << Fraction)) {}
-			
-		constexpr UFixedBase(const DecimalLiteral & value)
-			: value(static_cast<InternalType>(value * Scale)) {}
-			
-		constexpr UFixedBase(const DecimalLiteralF & value)
-			: value(static_cast<InternalType>(value * Scale)) {}
-			
-		constexpr UFixedBase(const DecimalLiteralL & value)
-			: value(static_cast<InternalType>(value * Scale)) {}
+		constexpr UFixedBase(const char & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<char, InternalType> >(value) << Fraction)) {}
+
+		constexpr UFixedBase(const unsigned char & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<unsigned char, InternalType> >(value) << Fraction)) {}
+
+		constexpr UFixedBase(const signed char & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<signed char, InternalType> >(value) << Fraction)) {}
+
+		constexpr UFixedBase(const unsigned short int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<unsigned short int, InternalType> >(value) << Fraction)) {}
+
+		constexpr UFixedBase(const signed short int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<signed short int, InternalType> >(value) << Fraction)) {}
+
+		constexpr UFixedBase(const unsigned int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<unsigned int, InternalType> >(value) << Fraction)) {}
+
+		constexpr UFixedBase(const signed int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<signed int, InternalType> >(value) << Fraction)) {}
+
+		constexpr UFixedBase(const unsigned long int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<unsigned long int, InternalType> >(value) << Fraction)) {}
+
+		constexpr UFixedBase(const signed long int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<signed long int, InternalType> >(value) << Fraction)) {}
+
+		constexpr UFixedBase(const unsigned long long int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<unsigned long long int, InternalType> >(value) << Fraction)) {}
+
+		constexpr UFixedBase(const signed long long int & value)
+			: value(static_cast<InternalType>(static_cast< LargerType<signed long long int, InternalType> >(value) << Fraction)) {}
+
+		constexpr UFixedBase(const double & value)
+			: value(static_cast<InternalType>(value * static_cast<double>(Scale))) {}
+
+		constexpr UFixedBase(const float & value)
+			: value(static_cast<InternalType>(value * static_cast<float>(Scale))) {}
+
+		constexpr UFixedBase(const long double & value)
+			: value(static_cast<InternalType>(value * static_cast<long double>(Scale))) {}
 	};
 }
 FIXED_POINTS_END_NAMESPACE

--- a/src/FixedPoints/UFixedFreeFunctions.h
+++ b/src/FixedPoints/UFixedFreeFunctions.h
@@ -275,15 +275,20 @@ constexpr auto operator /(const UFixed<IntegerLeft, FractionLeft> & left, const 
 	}
 	
 #define OPERATORS( opType, op ) \
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteral, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteralU, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteralL, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteralUL, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteralLL, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::IntegerLiteralULL, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::DecimalLiteral, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::DecimalLiteralF, op )\
-	opType##_OPERATOR( FIXED_POINTS_DETAILS::DecimalLiteralL, op )
+	opType##_OPERATOR( char, op )\
+	opType##_OPERATOR( unsigned char, op )\
+	opType##_OPERATOR( signed char, op )\
+	opType##_OPERATOR( unsigned short int, op )\
+	opType##_OPERATOR( signed short int, op )\
+	opType##_OPERATOR( unsigned int, op )\
+	opType##_OPERATOR( signed int, op )\
+	opType##_OPERATOR( unsigned long int, op )\
+	opType##_OPERATOR( signed long int, op )\
+	opType##_OPERATOR( unsigned long long int, op )\
+	opType##_OPERATOR( signed long long int, op )\
+	opType##_OPERATOR( float, op )\
+	opType##_OPERATOR( double, op )\
+	opType##_OPERATOR( long double, op )
 	
 #define LOGIC_OPERATORS( op ) OPERATORS( LOGIC, op )
 #define ARITHMETIC_OPERATORS( op ) OPERATORS( ARITHMETIC, op )


### PR DESCRIPTION
Replaces inferred types of literals with fundamental types.

Inferred types weren't actually providing any advantage over just covering the fundamental types.

In addition, inferring the types of literals was causing an issue on Teensy boards as reported by #21.
As of Teensyduino version 1.25, decimal literals are treated as `float`.
(i.e. Teensyduino is doing non-standard things.)
