### PR TITLE
Fix bug in roundFixed

### DIFF
--- a/src/FixedPoints/Utils.h
+++ b/src/FixedPoints/Utils.h
@@ -127,7 +127,7 @@ template< unsigned Integer, unsigned Fraction >
 constexpr UFixed<Integer, Fraction> roundFixed(const UFixed<Integer, Fraction> & value)
 {
 	using OutputType = UFixed<Integer, Fraction>;
-	return ((value.getFraction() >= OutputType(0.5).getFraction()) != 0) ? ceilFixed(value) : floorFixed(value);
+	return (value.getFraction() >= OutputType(0.5).getFraction()) ? ceilFixed(value) : floorFixed(value);
 }
 
 template< unsigned Integer, unsigned Fraction >
@@ -136,8 +136,8 @@ constexpr SFixed<Integer, Fraction> roundFixed(const SFixed<Integer, Fraction> &
 	using OutputType = SFixed<Integer, Fraction>;
 	return		
 		signbitFixed(value)
-		? ((value.getFraction() <= OutputType(0.5).getFraction()) != 0) ? floorFixed(value) : ceilFixed(value)
-		: ((value.getFraction() >= OutputType(0.5).getFraction()) != 0) ? ceilFixed(value) : floorFixed(value);
+		? (value.getFraction() <= OutputType(0.5).getFraction()) ? floorFixed(value) : ceilFixed(value)
+		: (value.getFraction() >= OutputType(0.5).getFraction()) ? ceilFixed(value) : floorFixed(value);
 }
 
 template< unsigned Integer, unsigned Fraction >


### PR DESCRIPTION
The bug was due to part of the former code being left in by mistake.

Part of the problem was that implicit boolean conversion was masking the problem.
If integers weren't implicitly convertable to booleans and vice versa then this would have been an error.

Thankfully tests seem to imply that this still saves a small amount of memory compared to the approach it replaced, though not as much as once thought.

Solves #31