### PR TITLE
Fix width of integer literal in Scale definition

### DIFF
--- a/src/FixedPoints/SFixed.h
+++ b/src/FixedPoints/SFixed.h
@@ -41,7 +41,7 @@ public:
 	constexpr const static uintmax_t LogicalSize = IntegerSize + FractionSize;
 	constexpr const static uintmax_t InternalSize = FIXED_POINTS_DETAILS::BitSize<InternalType>::Value;	
 	
-	constexpr const static uintmax_t Scale = 1ULL << FractionSize;
+	constexpr const static uintmax_t Scale = UINTMAX_C(1) << FractionSize;
 	
 public:
 	constexpr const static ShiftType IntegerShift = FractionSize;

--- a/src/FixedPoints/UFixed.h
+++ b/src/FixedPoints/UFixed.h
@@ -41,7 +41,7 @@ public:
 	constexpr const static uintmax_t LogicalSize = IntegerSize + FractionSize;
 	constexpr const static uintmax_t InternalSize = FIXED_POINTS_DETAILS::BitSize<InternalType>::Value;
 	
-	constexpr const static uintmax_t Scale = 1ULL << FractionSize;
+	constexpr const static uintmax_t Scale = UINTMAX_C(1) << FractionSize;
 	
 public:
 	constexpr const static ShiftType IntegerShift = FractionSize;


### PR DESCRIPTION
Previously the literal was of type `unsigned long long`.
This uses a macro from the fixed-width literal API to give the literal a type of `uintmax_t`.

Closes #47.