### PR TITLE
Remove void in zero-parameter functions

### DIFF
--- a/src/FixedPoints/Details.h
+++ b/src/FixedPoints/Details.h
@@ -43,7 +43,7 @@ namespace FIXED_POINTS_DETAILS
 	template< typename T >
 	struct BitSize
 	{
-		BitSize(void) = delete;
+		BitSize() = delete;
 		constexpr static const auto Value = sizeof(T) * CHAR_BIT;
 	};
 
@@ -77,14 +77,14 @@ namespace FIXED_POINTS_DETAILS
 	template< unsigned Bits, typename T, typename... Ts >
 	struct LeastTypeHelper<Bits, T, Ts... >
 	{
-		LeastTypeHelper(void) = delete;
+		LeastTypeHelper() = delete;
 		using Type = ConditionalT<(Bits <= BitSize<T>::Value), T, typename LeastTypeHelper<Bits, Ts...>::Type>;
 	};
 
 	template< unsigned Bits >
 	struct LeastTypeHelper<Bits>
 	{
-		LeastTypeHelper(void) = delete;
+		LeastTypeHelper() = delete;
 		using Type = void;
 	};
 
@@ -96,7 +96,7 @@ namespace FIXED_POINTS_DETAILS
 	struct LeastUIntDef
 	{
 		static_assert(Bits <= BitSize<uintmax_t>::Value, "No type large enough");
-		LeastUIntDef(void) = delete;
+		LeastUIntDef() = delete;
 		using Type = LeastType<Bits, uint_least8_t, uint_least16_t, uint_least32_t, uint_least64_t, uintmax_t>;
 	};
 	
@@ -108,7 +108,7 @@ namespace FIXED_POINTS_DETAILS
 	struct LeastIntDef
 	{
 		static_assert(Bits <= BitSize<intmax_t>::Value, "No type large enough");
-		LeastIntDef(void) = delete;
+		LeastIntDef() = delete;
 		using Type = LeastType<Bits, int_least8_t, int_least16_t, int_least32_t, int_least64_t, intmax_t>;
 	};
 
@@ -118,21 +118,21 @@ namespace FIXED_POINTS_DETAILS
 	template< unsigned Bits >
 	struct MsbMask
 	{
-		MsbMask(void) = delete;
+		MsbMask() = delete;
 		constexpr const static LeastUInt<Bits> Value = (1ull << (Bits - 1));
 	};
 
 	template< unsigned Bits >
 	struct IdentityMask
 	{
-		IdentityMask(void) = delete;
+		IdentityMask() = delete;
 		constexpr const static LeastUInt<Bits> Value = 1 | (IdentityMask<Bits - 1>::Value << 1);
 	};
 
 	template<>
 	struct IdentityMask<0>
 	{
-		IdentityMask(void) = delete;
+		IdentityMask() = delete;
 		constexpr const static LeastUInt<0> Value = 0;
 	};
 	

--- a/src/FixedPoints/SFixed.h
+++ b/src/FixedPoints/SFixed.h
@@ -64,7 +64,7 @@ protected:
 
 	public:
 		constexpr inline explicit RawType(const InternalType & value) : value(value) {}
-		constexpr inline explicit operator InternalType(void) const { return this->value; }
+		constexpr inline explicit operator InternalType() const { return this->value; }
 	};
 
 protected:
@@ -74,7 +74,7 @@ protected:
 	constexpr SFixed(const RawType & value);
 
 public:
-	constexpr SFixed(void);
+	constexpr SFixed();
 	constexpr SFixed(const IntegerType & integer, const FractionType & fraction);
 	constexpr SFixed(const char & value);
 	constexpr SFixed(const unsigned char & value);
@@ -91,23 +91,23 @@ public:
 	constexpr SFixed(const float & value);
 	constexpr SFixed(const long double & value);
 
-	constexpr InternalType getInternal(void) const;
-	constexpr IntegerType getInteger(void) const;
-	constexpr FractionType getFraction(void) const;
+	constexpr InternalType getInternal() const;
+	constexpr IntegerType getInteger() const;
+	constexpr FractionType getFraction() const;
 
-	constexpr explicit operator IntegerType(void) const;
-	constexpr explicit operator float(void) const;
-	constexpr explicit operator double(void) const;
-	constexpr explicit operator long double(void) const;
+	constexpr explicit operator IntegerType() const;
+	constexpr explicit operator float() const;
+	constexpr explicit operator double() const;
+	constexpr explicit operator long double() const;
 
 	template< unsigned IntegerOut, unsigned FractionOut >
-	constexpr explicit operator SFixed<IntegerOut, FractionOut>(void) const;
+	constexpr explicit operator SFixed<IntegerOut, FractionOut>() const;
 
 	constexpr static SFixed fromInternal(const InternalType & value);
 
-	constexpr SFixed operator -(void) const;
-	SFixed & operator ++(void);
-	SFixed & operator --(void);
+	constexpr SFixed operator -() const;
+	SFixed & operator ++();
+	SFixed & operator --();
 	SFixed & operator +=(const SFixed & other);
 	SFixed & operator -=(const SFixed & other);
 	SFixed & operator *=(const SFixed & other);

--- a/src/FixedPoints/SFixedMemberFunctions.h
+++ b/src/FixedPoints/SFixedMemberFunctions.h
@@ -25,7 +25,7 @@ constexpr SFixed<Integer, Fraction>::SFixed(const RawType & value)
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr SFixed<Integer, Fraction>::SFixed(void)
+constexpr SFixed<Integer, Fraction>::SFixed()
 	: value(0)
 {
 }
@@ -125,19 +125,19 @@ constexpr SFixed<Integer, Fraction>::SFixed(const long double & value)
 //
 
 template< unsigned Integer, unsigned Fraction >
-constexpr typename SFixed<Integer, Fraction>::InternalType SFixed<Integer, Fraction>::getInternal(void) const
+constexpr typename SFixed<Integer, Fraction>::InternalType SFixed<Integer, Fraction>::getInternal() const
 {
 	return this->value;
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr typename SFixed<Integer, Fraction>::IntegerType SFixed<Integer, Fraction>::getInteger(void) const
+constexpr typename SFixed<Integer, Fraction>::IntegerType SFixed<Integer, Fraction>::getInteger() const
 {
 	return (static_cast<IntegerType>(this->value >> IntegerShift) & IntegerMask) | ((this->value < 0) ? ~IntegerMask : 0);
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr typename SFixed<Integer, Fraction>::FractionType SFixed<Integer, Fraction>::getFraction(void) const
+constexpr typename SFixed<Integer, Fraction>::FractionType SFixed<Integer, Fraction>::getFraction() const
 {
 	return static_cast<FractionType>(this->value >> FractionShift) & FractionMask;
 }
@@ -147,13 +147,13 @@ constexpr typename SFixed<Integer, Fraction>::FractionType SFixed<Integer, Fract
 //
 
 template< unsigned Integer, unsigned Fraction >
-constexpr SFixed<Integer, Fraction>::operator IntegerType(void) const
+constexpr SFixed<Integer, Fraction>::operator IntegerType() const
 {
 	return this->getInteger();
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr SFixed<Integer, Fraction>::operator float(void) const
+constexpr SFixed<Integer, Fraction>::operator float() const
 {
 	return (1.0F / Scale) *
 	static_cast<InternalType>
@@ -162,7 +162,7 @@ constexpr SFixed<Integer, Fraction>::operator float(void) const
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr SFixed<Integer, Fraction>::operator double(void) const
+constexpr SFixed<Integer, Fraction>::operator double() const
 {
 	return (1.0 / Scale) *
 	static_cast<InternalType>
@@ -171,7 +171,7 @@ constexpr SFixed<Integer, Fraction>::operator double(void) const
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr SFixed<Integer, Fraction>::operator long double(void) const
+constexpr SFixed<Integer, Fraction>::operator long double() const
 {
 	return (1.0L / Scale) *
 	static_cast<InternalType>
@@ -181,7 +181,7 @@ constexpr SFixed<Integer, Fraction>::operator long double(void) const
 
 template< unsigned Integer, unsigned Fraction >
 template< unsigned IntegerOut, unsigned FractionOut >
-constexpr SFixed<Integer, Fraction>::operator SFixed<IntegerOut, FractionOut>(void) const
+constexpr SFixed<Integer, Fraction>::operator SFixed<IntegerOut, FractionOut>() const
 {	
 	using OutputType = SFixed<IntegerOut, FractionOut>;
 	using OutputInternalType = typename OutputType::InternalType;
@@ -209,7 +209,7 @@ constexpr SFixed<Integer, Fraction> SFixed<Integer, Fraction>::fromInternal(cons
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr SFixed<Integer, Fraction> SFixed<Integer, Fraction>::operator -(void) const
+constexpr SFixed<Integer, Fraction> SFixed<Integer, Fraction>::operator -() const
 {
 	return SFixed<Integer, Fraction>::fromInternal(-this->value);
 }
@@ -219,14 +219,14 @@ constexpr SFixed<Integer, Fraction> SFixed<Integer, Fraction>::operator -(void) 
 //
 
 template< unsigned Integer, unsigned Fraction >
-SFixed<Integer, Fraction> & SFixed<Integer, Fraction>::operator ++(void)
+SFixed<Integer, Fraction> & SFixed<Integer, Fraction>::operator ++()
 {
 	this->value += (1 << FractionSize);
 	return *this;
 }
 
 template< unsigned Integer, unsigned Fraction >
-SFixed<Integer, Fraction> & SFixed<Integer, Fraction>::operator --(void)
+SFixed<Integer, Fraction> & SFixed<Integer, Fraction>::operator --()
 {
 	this->value -= (1 << FractionSize);
 	return *this;

--- a/src/FixedPoints/UFixed.h
+++ b/src/FixedPoints/UFixed.h
@@ -64,7 +64,7 @@ protected:
 
 	public:
 		constexpr inline explicit RawType(const InternalType & value) : value(value) {}
-		constexpr inline explicit operator InternalType(void) const { return this->value; }
+		constexpr inline explicit operator InternalType() const { return this->value; }
 	};
 
 protected:
@@ -74,7 +74,7 @@ protected:
 	constexpr UFixed(const RawType & value);
 	
 public:
-	constexpr UFixed(void);
+	constexpr UFixed();
 	constexpr UFixed(const IntegerType & integer, const FractionType & fraction);
 	constexpr UFixed(const char & value);
 	constexpr UFixed(const unsigned char & value);
@@ -92,22 +92,22 @@ public:
 	constexpr UFixed(const long double & value);
 	
 public:
-	constexpr InternalType getInternal(void) const;
-	constexpr IntegerType getInteger(void) const;
-	constexpr FractionType getFraction(void) const;
+	constexpr InternalType getInternal() const;
+	constexpr IntegerType getInteger() const;
+	constexpr FractionType getFraction() const;
 
-	constexpr explicit operator IntegerType(void) const;
-	constexpr explicit operator float(void) const;
-	constexpr explicit operator double(void) const;
-	constexpr explicit operator long double(void) const;
+	constexpr explicit operator IntegerType() const;
+	constexpr explicit operator float() const;
+	constexpr explicit operator double() const;
+	constexpr explicit operator long double() const;
 
 	template< unsigned IntegerOut, unsigned FractionOut >
-	constexpr explicit operator UFixed<IntegerOut, FractionOut>(void) const;
+	constexpr explicit operator UFixed<IntegerOut, FractionOut>() const;
 
 	constexpr static UFixed fromInternal(const InternalType & value);
 
-	UFixed & operator ++(void);
-	UFixed & operator --(void);
+	UFixed & operator ++();
+	UFixed & operator --();
 	UFixed & operator +=(const UFixed & other);
 	UFixed & operator -=(const UFixed & other);
 	UFixed & operator *=(const UFixed & other);

--- a/src/FixedPoints/UFixedMemberFunctions.h
+++ b/src/FixedPoints/UFixedMemberFunctions.h
@@ -25,7 +25,7 @@ constexpr UFixed<Integer, Fraction>::UFixed(const RawType & value)
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr UFixed<Integer, Fraction>::UFixed(void)
+constexpr UFixed<Integer, Fraction>::UFixed()
 	: value(0)
 {
 }
@@ -125,19 +125,19 @@ constexpr UFixed<Integer, Fraction>::UFixed(const long double & value)
 //
 
 template< unsigned Integer, unsigned Fraction >
-constexpr typename UFixed<Integer, Fraction>::InternalType UFixed<Integer, Fraction>::getInternal(void) const
+constexpr typename UFixed<Integer, Fraction>::InternalType UFixed<Integer, Fraction>::getInternal() const
 {
 	return this->value;
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr typename UFixed<Integer, Fraction>::IntegerType UFixed<Integer, Fraction>::getInteger(void) const
+constexpr typename UFixed<Integer, Fraction>::IntegerType UFixed<Integer, Fraction>::getInteger() const
 {
 	return static_cast<IntegerType>(this->value >> IntegerShift) & IntegerMask;
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr typename UFixed<Integer, Fraction>::FractionType UFixed<Integer, Fraction>::getFraction(void) const
+constexpr typename UFixed<Integer, Fraction>::FractionType UFixed<Integer, Fraction>::getFraction() const
 {
 	return static_cast<FractionType>(this->value >> FractionShift) & FractionMask;
 }
@@ -147,32 +147,32 @@ constexpr typename UFixed<Integer, Fraction>::FractionType UFixed<Integer, Fract
 //
 
 template< unsigned Integer, unsigned Fraction >
-constexpr UFixed<Integer, Fraction>::operator IntegerType(void) const
+constexpr UFixed<Integer, Fraction>::operator IntegerType() const
 {
 	return this->getInteger();
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr UFixed<Integer, Fraction>::operator float(void) const
+constexpr UFixed<Integer, Fraction>::operator float() const
 {
 	return ((this->value & IdentityMask) * (1.0F / Scale));
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr UFixed<Integer, Fraction>::operator double(void) const
+constexpr UFixed<Integer, Fraction>::operator double() const
 {
 	return ((this->value & IdentityMask) * (1.0 / Scale));
 }
 
 template< unsigned Integer, unsigned Fraction >
-constexpr UFixed<Integer, Fraction>::operator long double(void) const
+constexpr UFixed<Integer, Fraction>::operator long double() const
 {
 	return ((this->value & IdentityMask) * (1.0L / Scale));
 }
 
 template< unsigned Integer, unsigned Fraction >
 template< unsigned IntegerOut, unsigned FractionOut >
-constexpr UFixed<Integer, Fraction>::operator UFixed<IntegerOut, FractionOut>(void) const
+constexpr UFixed<Integer, Fraction>::operator UFixed<IntegerOut, FractionOut>() const
 {
 	using OutputType = UFixed<IntegerOut, FractionOut>;
 	using OutputInternalType = typename OutputType::InternalType;
@@ -204,14 +204,14 @@ constexpr UFixed<Integer, Fraction> UFixed<Integer, Fraction>::fromInternal(cons
 //
 
 template< unsigned Integer, unsigned Fraction >
-UFixed<Integer, Fraction> & UFixed<Integer, Fraction>::operator ++(void)
+UFixed<Integer, Fraction> & UFixed<Integer, Fraction>::operator ++()
 {
 	this->value += (1 << FractionSize);
 	return *this;
 }
 
 template< unsigned Integer, unsigned Fraction >
-UFixed<Integer, Fraction> & UFixed<Integer, Fraction>::operator --(void)
+UFixed<Integer, Fraction> & UFixed<Integer, Fraction>::operator --()
 {
 	this->value -= (1 << FractionSize);
 	return *this;

--- a/src/FixedPoints/Utils.h
+++ b/src/FixedPoints/Utils.h
@@ -63,7 +63,7 @@ constexpr UFixed<Integer, Fraction> nextafterFixed(const UFixed<Integer, Fractio
 
 #if !defined(FIXED_POINTS_NO_RANDOM)
 template< unsigned Integer, unsigned Fraction >
-UFixed<Integer, Fraction> randomUFixed(void);
+UFixed<Integer, Fraction> randomUFixed();
 
 template< unsigned Integer, unsigned Fraction >
 UFixed<Integer, Fraction> randomUFixed(const UFixed<Integer, Fraction> & exclusiveUpperBound);
@@ -78,7 +78,7 @@ UFixed<Integer, Fraction> randomUFixed(const UFixed<Integer, Fraction> & inclusi
 
 #if !defined(FIXED_POINTS_NO_RANDOM)
 template< unsigned Integer, unsigned Fraction >
-SFixed<Integer, Fraction> randomSFixed(void);
+SFixed<Integer, Fraction> randomSFixed();
 
 template< unsigned Integer, unsigned Fraction >
 SFixed<Integer, Fraction> randomSFixed(const SFixed<Integer, Fraction> & exclusiveUpperBound);
@@ -204,7 +204,7 @@ constexpr UFixed<Integer, Fraction> nextafterFixed(const UFixed<Integer, Fractio
 
 #if !defined(FIXED_POINTS_NO_RANDOM)
 template< unsigned Integer, unsigned Fraction >
-UFixed<Integer, Fraction> randomUFixed(void)
+UFixed<Integer, Fraction> randomUFixed()
 {
 	using InternalType = typename UFixed<Integer, Fraction>::InternalType;
 	return UFixed<Integer, Fraction>::fromInternal(FIXED_POINTS_DETAILS::RandomHelper<InternalType>::Random());
@@ -231,7 +231,7 @@ UFixed<Integer, Fraction> randomUFixed(const UFixed<Integer, Fraction> & inclusi
 
 #if !defined(FIXED_POINTS_NO_RANDOM)
 template< unsigned Integer, unsigned Fraction >
-SFixed<Integer, Fraction> randomSFixed(void)
+SFixed<Integer, Fraction> randomSFixed()
 {
 	using InternalType = typename SFixed<Integer, Fraction>::InternalType;
 	return SFixed<Integer, Fraction>::fromInternal(FIXED_POINTS_DETAILS::RandomHelper<InternalType>::Random());


### PR DESCRIPTION
The isocpp FAQ recommends against this practice.

Closes #62.