### PR TITLE
Add postincrement and postdecrement operators

### DIFF
--- a/src/FixedPoints/SFixedFreeFunctions.h
+++ b/src/FixedPoints/SFixedFreeFunctions.h
@@ -29,6 +29,26 @@ constexpr SFixed<Integer * 2, Fraction * 2> multiply(const SFixed<Integer, Fract
 }
 
 //
+// Postincrement and Postdecrement
+//
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> operator ++(SFixed<Integer, Fraction> & value, int)
+{
+	const auto oldValue = value;
+	++value;
+	return oldValue;
+}
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> operator --(SFixed<Integer, Fraction> & value, int)
+{
+	const auto oldValue = value;
+	--value;
+	return oldValue;
+}
+
+//
 // Basic Logic Operations
 //
 

--- a/src/FixedPoints/UFixedFreeFunctions.h
+++ b/src/FixedPoints/UFixedFreeFunctions.h
@@ -29,6 +29,26 @@ constexpr UFixed<Integer * 2, Fraction * 2> multiply(const UFixed<Integer, Fract
 }
 
 //
+// Postincrement and Postdecrement
+//
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> operator ++(UFixed<Integer, Fraction> & value, int)
+{
+	const auto oldValue = value;
+	++value;
+	return oldValue;
+}
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> operator --(UFixed<Integer, Fraction> & value, int)
+{
+	const auto oldValue = value;
+	--value;
+	return oldValue;
+}
+
+//
 // Basic Logic Operations
 //
 


### PR DESCRIPTION
These operators are added purely for the sake of completion.

I strongly advise against using them because there's a vanishingly small chance they could produce more code than their prefix counterparts, and they're redundant anyway.

In most cases using either form of the `++` and `--` operators on fixed point types is likely to be less clear than using `+`, `+=`, `-` or `-=` because it isn't immediately clear whether the behaviour is `+ 1`/`- 1` or `+ Epsilon`/`- Epsilon`, hence `+`, `+=`, `-` and `-=` should be preferred when possible.

(`++` and `--` are in fact implemented in terms of `+=` and `-=` anyway, so it's likely the same code will be produced either way.)

Resolves #68