### PR TITLE
Add conversion operators for converting between SFixed and UFixed

### DIFF
--- a/src/FixedPoints/SFixed.h
+++ b/src/FixedPoints/SFixed.h
@@ -23,6 +23,9 @@ FIXED_POINTS_BEGIN_NAMESPACE
 //
 
 template< unsigned Integer, unsigned Fraction >
+class UFixed;
+
+template< unsigned Integer, unsigned Fraction >
 class SFixed
 {
 public:
@@ -102,6 +105,11 @@ public:
 
 	template< unsigned IntegerOut, unsigned FractionOut >
 	constexpr explicit operator SFixed<IntegerOut, FractionOut>() const;
+
+	template< unsigned IntegerOut, unsigned FractionOut >
+	constexpr explicit operator UFixed<IntegerOut, FractionOut>() const;
+
+	constexpr explicit operator UFixed<Integer + 1, Fraction>() const;
 
 	static constexpr SFixed fromInternal(const InternalType & value);
 

--- a/src/FixedPoints/SFixedMemberFunctions.h
+++ b/src/FixedPoints/SFixedMemberFunctions.h
@@ -198,6 +198,25 @@ constexpr SFixed<Integer, Fraction>::operator SFixed<IntegerOut, FractionOut>() 
 		OutputType::fromInternal(this->value);
 }
 
+template< unsigned Integer, unsigned Fraction >
+template< unsigned IntegerOut, unsigned FractionOut >
+constexpr SFixed<Integer, Fraction>::operator UFixed<IntegerOut, FractionOut>() const
+{
+	using OutputType = UFixed<IntegerOut, FractionOut>;
+	using IntermediaryType = SFixed<IntegerOut - 1, FractionOut>;
+
+	return static_cast<OutputType>(static_cast<IntermediaryType>(*this));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::operator UFixed<Integer + 1, Fraction>() const
+{
+	using OutputType = UFixed<Integer + 1, Fraction>;
+	using OutputInternalType = typename OutputType::InternalType;
+	
+	return OutputType::fromInternal(static_cast<OutputInternalType>(this->value));
+}
+
 //
 // Static Functions
 //

--- a/src/FixedPoints/UFixed.h
+++ b/src/FixedPoints/UFixed.h
@@ -23,6 +23,9 @@ FIXED_POINTS_BEGIN_NAMESPACE
 //
 
 template< unsigned Integer, unsigned Fraction >
+class SFixed;
+
+template< unsigned Integer, unsigned Fraction >
 class UFixed
 {
 public:
@@ -103,6 +106,11 @@ public:
 
 	template< unsigned IntegerOut, unsigned FractionOut >
 	constexpr explicit operator UFixed<IntegerOut, FractionOut>() const;
+
+	template< unsigned IntegerOut, unsigned FractionOut >
+	constexpr explicit operator SFixed<IntegerOut, FractionOut>() const;
+
+	constexpr explicit operator SFixed<Integer - 1, Fraction>() const;
 
 	static constexpr UFixed fromInternal(const InternalType & value);
 

--- a/src/FixedPoints/UFixedMemberFunctions.h
+++ b/src/FixedPoints/UFixedMemberFunctions.h
@@ -189,6 +189,25 @@ constexpr UFixed<Integer, Fraction>::operator UFixed<IntegerOut, FractionOut>() 
 		OutputType::fromInternal(this->value);
 }
 
+template< unsigned Integer, unsigned Fraction >
+template< unsigned IntegerOut, unsigned FractionOut >
+constexpr UFixed<Integer, Fraction>::operator SFixed<IntegerOut, FractionOut>() const
+{
+	using OutputType = SFixed<IntegerOut, FractionOut>;
+	using IntermediaryType = UFixed<IntegerOut + 1, FractionOut>;
+
+	return static_cast<OutputType>(static_cast<IntermediaryType>(*this));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::operator SFixed<Integer - 1, Fraction>() const
+{
+	using OutputType = SFixed<Integer - 1, Fraction>;
+	using OutputInternalType = typename OutputType::InternalType;
+	
+	return OutputType::fromInternal(static_cast<OutputInternalType>(this->value));
+}
+
 //
 // Static Functions
 //


### PR DESCRIPTION
This will finally allow SFixed and UFixed to be converted to and from each other.

As simple as this implementation seems, it took quite a bit of thought to come up with it.

Early on I realised that I could implement the function by leveraging the 'scaling' cast operator to perform the scaling and then having a '1-to-1' operator that simply converts the internal representation of the same width by effectively leveraging the built-in integer cast operators, but the real problem was figuring out how to have those two cases coexist. Originally I went down the wrong track by trying to create a specialisation, and at one point I was considering using a template class and some specialisation, but then I suddenly realised that I could introduce a non-template cast operator to do the job of the non-scaling/direct operation and suddenly the rest just slotted into place.

It took me quite some time to actually commit this because I wanted to double check that I'd got the order of operations correct. As it happens, I had got it right first time, so I ended up wasting a lot of time creating the code to check when I could have committed it straight away, but at least I know for definite.

All in all I'm glad I put this particular issue off for a few years because [my original attempt](https://github.com/Pharap/FixedPointsArduino/commit/3fe70d1b7c2f72d8e1159d845ebc16dd52631371) from 2018 was absolutely awful (I think perhaps I was following some bad advice I got from StackOverflow) and I feel that I've been able to pull off something much better than my original intended implementation.

Resolves #20