### PR TITLE
Removed the platform limitation

### DIFF
--- a/library.json
+++ b/library.json
@@ -13,6 +13,5 @@
     "url": "https://github.com/Pharap/FixedPointsArduino.git"
   },
   "license": "Apache-2.0",
-  "version": "1.1.0",
-  "frameworks": "arduino"
+  "version": "1.1.0",  
 }

--- a/library.json
+++ b/library.json
@@ -13,5 +13,5 @@
     "url": "https://github.com/Pharap/FixedPointsArduino.git"
   },
   "license": "Apache-2.0",
-  "version": "1.1.0",  
+  "version": "1.1.0"
 }

--- a/src/FixedPoints/Details.h
+++ b/src/FixedPoints/Details.h
@@ -14,7 +14,11 @@
 
 #pragma once
 
+#ifdef ARDUINO
 #include <Arduino.h>
+#else
+#endif
+
 #include <limits.h>
 #include <stdint.h>
 


### PR DESCRIPTION
Hi
You have explicitly declared that this library is only compatible with the Arduino platform. But isn't this extremely cross-platform-compatible? I propose you remove the platform limitations unless there is a reason for them.

Personally, I want to be able to run unit tests on my PC and right now I cannot becuase PlatformIO refuses to build this library for the native platform.