### PR TITLE
Fix bug in IdentityMask calculation

### DIFF
--- a/src/FixedPoints/Details.h
+++ b/src/FixedPoints/Details.h
@@ -126,7 +126,7 @@ namespace FIXED_POINTS_DETAILS
 	struct IdentityMask
 	{
 		IdentityMask() = delete;
-		static constexpr LeastUInt<Bits> Value = 1 | (IdentityMask<Bits - 1>::Value << 1);
+		static constexpr LeastUInt<Bits> Value = 1 | (static_cast<LeastUInt<Bits>>(IdentityMask<Bits - 1>::Value) << 1);
 	};
 
 	template<>


### PR DESCRIPTION
The bit width of the type was not being sufficiently increased, which was leading to dropped bits, which in turn caused problems with floating point conversion and possibly other problems.