### PR TITLE
Fix SFixed conversion by making ShiftType signed

### DIFF
--- a/src/FixedPoints/SFixed.h
+++ b/src/FixedPoints/SFixed.h
@@ -44,7 +44,7 @@ public:
 
 	static constexpr uintmax_t InternalSize = FIXED_POINTS_DETAILS::BitSize<InternalType>::Value;
 	
-	using ShiftType = FIXED_POINTS_DETAILS::LeastUInt<LogicalSize>;
+	using ShiftType = FIXED_POINTS_DETAILS::LeastInt<LogicalSize>;
 	using MaskType = FIXED_POINTS_DETAILS::LeastUInt<LogicalSize>;
 		
 public:


### PR DESCRIPTION
`SFixed`'s conversion operator isn't functioning correctly because the shifting is being done with an unsigned type. This rectifies that by changing `SFixed`'s `ShiftType` to a signed integer type.