### PR TITLE
Depend on Arduino.h only if platform is AVR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS
+                       INCLUDE_DIRS "src"
+                       PRIV_INCLUDE_DIRS "src/FixedPointsCommon" "src/FixedPoints")

--- a/src/FixedPoints/Details.h
+++ b/src/FixedPoints/Details.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <Arduino.h>
 #include <limits.h>
 #include <stdint.h>
 
@@ -33,6 +32,8 @@
 
 #if !defined(__AVR__)
 #define FIXED_POINTS_NO_RANDOM
+#else
+#include "Arduino.h"
 #endif
 
 // Pay no attention to the man behind the curtains


### PR DESCRIPTION
When the platform is not Arduino, we can't use
random(), but that appears to be the only Arduino
dep in the entire library. Avoiding a dependency
on Arduino allows using the FixedPoint library
on native, which is useful for unit tests.